### PR TITLE
Make NI searches case insensitive

### DIFF
--- a/solution/dqt.domain/QTS/QualifiedTeachersService.cs
+++ b/solution/dqt.domain/QTS/QualifiedTeachersService.cs
@@ -18,21 +18,23 @@ namespace dqt.domain.QTS
         {
             _qualifiedTeachersRepository = repo;
         }
-        
+
         public async Task<IEnumerable<QualifiedTeacherDTO>> GetQualifiedTeacherRecords(string teacherReferenceNumber, string nationalInsuranceNumber)
         {
             var qts = await _qualifiedTeachersRepository.FindAsync(x => x.Trn == teacherReferenceNumber);
-            
+
             if (!qts.Any())
             {
                 if (!string.IsNullOrWhiteSpace(nationalInsuranceNumber))
                 {
-                    qts = await _qualifiedTeachersRepository.FindAsync(x => x.NINumber == nationalInsuranceNumber);
+                    qts = await _qualifiedTeachersRepository.FindAsync(
+                        x => string.Equals(x.NINumber, nationalInsuranceNumber, StringComparison.CurrentCultureIgnoreCase)
+                        );
                 }
             }
             if(qts == null)
                 return null;
-            
+
             var qtsList = new List<QualifiedTeacherDTO>();
             qts.ToList().ForEach(model=> {
                 qtsList.Add(ConvertToDto(model));

--- a/solution/dqt.integrationtests/QualifiedTeacherStatusServiceTests.cs
+++ b/solution/dqt.integrationtests/QualifiedTeacherStatusServiceTests.cs
@@ -122,6 +122,24 @@ namespace dqt.integrationtests
             Assert.Single(resultDto.Data);
         }
 
+        [Fact]
+        public async void Returns_SuccessResponseWithQualifiedTeacherRecords_WhenNIMatchesCaseInsenitively()
+        {
+            RequestInfo requestInfo = new RequestInfo()
+            {
+                TRN = "Test-TRN",
+                NINumber = "aP558641W"
+            };
+
+            var request = CreateMockHttpRequest(requestInfo);
+
+            var response = (OkObjectResult)await _qualifiedTeacherStatusService.Run(request.Object);
+            var resultDto = (ResultDTO<List<QualifiedTeacherDTO>>)response.Value;
+
+            Assert.Equal(200, response.StatusCode);
+            Assert.Single(resultDto.Data);
+        }
+
         private Mock<HttpRequest> CreateMockHttpRequest(RequestInfo requestDto, bool addAuthKey = true)
         {
             var mockRequest = new Mock<HttpRequest>();


### PR DESCRIPTION
While using the API, we noticed that NINO responses were mixed case. This change makes searching by NINO case insensitive.

I don't have this running locally, so please review carefully