### PR TITLE
Enforcing left '0' padded TRNs in responses

### DIFF
--- a/azure/infra/infra-deploy-pipelines.yml
+++ b/azure/infra/infra-deploy-pipelines.yml
@@ -9,7 +9,7 @@ stages:
   displayName: "Development Plan"
 
   jobs:
-  - job: devplan 
+  - job: devplan
     displayName: "Development Plan"
 
     pool:
@@ -20,7 +20,7 @@ stages:
     - task: charleszipp.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-installer.TerraformInstaller@0
       displayName: 'Installing Terraform $(Terraform.Version) for plan'
       inputs:
-        terraformVersion: 'latest'
+        terraformVersion: '0.14.9'
 
     - task: TerraformTaskV1@0
       name: TFInit
@@ -40,7 +40,7 @@ stages:
       displayName: 'Open KeyVault Firewall'
       inputs:
         azureSubscription: "azdo.pipelines.cip.S118D.armfe1ef140-8bef-4043-b5ee-c449e6f951ef"
-        TargetAzurePs: LatestVersion      
+        TargetAzurePs: LatestVersion
         ScriptType: InlineScript
         Inline: |
           # Setting Variables
@@ -52,9 +52,9 @@ stages:
           }
           $KeyVault = Get-AzKeyVault -ResourceGroupName $KeyVault.ResourceGroupName -VaultName $KeyVault.Name
           Write-Output 'Updating Key Vault rules...'
-          $KeyVault | Update-AzKeyVaultNetworkRuleSet -DefaultAction Allow 
+          $KeyVault | Update-AzKeyVaultNetworkRuleSet -DefaultAction Allow
           $LoopCount = 0
-          Write-Output "Waiting for Access..." 
+          Write-Output "Waiting for Access..."
           # This will check every 5 seconds, up to a maximum of 30 seconds
           Do {
               $AccessAllowed = $KeyVault | Get-AzKeyVaultSecret -ErrorAction SilentlyContinue
@@ -77,7 +77,7 @@ stages:
       condition: always()
       inputs:
         azureSubscription: "azdo.pipelines.cip.S118D.armfe1ef140-8bef-4043-b5ee-c449e6f951ef"
-        TargetAzurePs: LatestVersion 
+        TargetAzurePs: LatestVersion
         ScriptType: InlineScript
         Inline: |
           # Setting Variables
@@ -85,7 +85,7 @@ stages:
           $KeyVault = Get-AzResource -ResourceId $KeyVaultId -ErrorAction SilentlyContinue
           $KeyVault = Get-AzKeyVault -ResourceGroupName $KeyVault.ResourceGroupName -VaultName $KeyVault.Name
           Write-Output 'Updating Key Vault rules...'
-          $KeyVault | Update-AzKeyVaultNetworkRuleSet -DefaultAction Deny 
+          $KeyVault | Update-AzKeyVaultNetworkRuleSet -DefaultAction Deny
 
     - task: CopyFiles@2
       displayName: 'Stage Artifacts'
@@ -128,7 +128,8 @@ stages:
             - task: charleszipp.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-installer.TerraformInstaller@0
               displayName: 'Installing Terraform $(Terraform.Version) for apply'
               inputs:
-                terraformVersion: 'latest'
+                terraformVersion: '0.14.9'
+
 
             - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
               name: RepoCheckout
@@ -155,7 +156,7 @@ stages:
               displayName: 'Open KeyVault Firewall'
               inputs:
                 azureSubscription: "azdo.pipelines.cip.S118D.armfe1ef140-8bef-4043-b5ee-c449e6f951ef"
-                TargetAzurePs: LatestVersion      
+                TargetAzurePs: LatestVersion
                 ScriptType: InlineScript
                 Inline: |
                     # Setting Variables
@@ -167,9 +168,9 @@ stages:
                     }
                     $KeyVault = Get-AzKeyVault -ResourceGroupName $KeyVault.ResourceGroupName -VaultName $KeyVault.Name
                     Write-Output 'Updating Key Vault rules...'
-                    $KeyVault | Update-AzKeyVaultNetworkRuleSet -DefaultAction Allow 
+                    $KeyVault | Update-AzKeyVaultNetworkRuleSet -DefaultAction Allow
                     $LoopCount = 0
-                    Write-Output "Waiting for Access..." 
+                    Write-Output "Waiting for Access..."
                     # This will check every 5 seconds, up to a maximum of 30 seconds
                     Do {
                         $AccessAllowed = $KeyVault | Get-AzKeyVaultSecret -ErrorAction SilentlyContinue
@@ -183,7 +184,7 @@ stages:
               name: TFApply
               inputs:
                 command: 'apply'
-                runAzLogin: true  
+                runAzLogin: true
                 environmentServiceName: 'azdo.pipelines.cip.S118D.armfe1ef140-8bef-4043-b5ee-c449e6f951ef'
                 workingDirectory: '$(System.DefaultWorkingDirectory)/azure/infra/terraform'
                 commandOptions: '-var="input_region=$(REGION)" -var="input_environment=$(environment)"'
@@ -204,7 +205,7 @@ stages:
               condition: always()
               inputs:
                 azureSubscription: "azdo.pipelines.cip.S118D.armfe1ef140-8bef-4043-b5ee-c449e6f951ef"
-                TargetAzurePs: LatestVersion 
+                TargetAzurePs: LatestVersion
                 ScriptType: InlineScript
                 Inline: |
                     # Setting Variables
@@ -212,7 +213,7 @@ stages:
                     $KeyVault = Get-AzResource -ResourceId $KeyVaultId -ErrorAction SilentlyContinue
                     $KeyVault = Get-AzKeyVault -ResourceGroupName $KeyVault.ResourceGroupName -VaultName $KeyVault.Name
                     Write-Output 'Updating Key Vault rules...'
-                    $KeyVault | Update-AzKeyVaultNetworkRuleSet -DefaultAction Deny 
+                    $KeyVault | Update-AzKeyVaultNetworkRuleSet -DefaultAction Deny
 
 ####################################################################
 # Test
@@ -220,11 +221,11 @@ stages:
 
 - stage: testplan
   displayName: "Test Plan"
-  dependsOn: 
+  dependsOn:
   - devplan
 
   jobs:
-  - job: testplan 
+  - job: testplan
     displayName: "Test Plan"
 
     pool:
@@ -235,7 +236,7 @@ stages:
     - task: charleszipp.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-installer.TerraformInstaller@0
       displayName: 'Installing Terraform $(Terraform.Version) for plan'
       inputs:
-        terraformVersion: 'latest'
+        terraformVersion: '0.14.9'
 
     - task: TerraformTaskV1@0
       name: TFInit
@@ -244,7 +245,7 @@ stages:
         provider: 'azurerm'
         command: 'init'
         workingDirectory: '$(System.DefaultWorkingDirectory)/azure/infra/terraform'
-        commandOptions: '-backend-config="storage_account_name=s118d01tfbackendsa" -backend-config="container_name=s118t01testfstate"' 
+        commandOptions: '-backend-config="storage_account_name=s118d01tfbackendsa" -backend-config="container_name=s118t01testfstate"'
         backendServiceArm: 'azdo.pipelines.cip.S118T.arm03ce3ff5-9a61-4525-a063-6ecde34874cf'
         backendAzureRmResourceGroupName: 's118t01-tfbackend'
         backendAzureRmStorageAccountName: 's118t01tfbackendsa'
@@ -266,9 +267,9 @@ stages:
           }
           $KeyVault = Get-AzKeyVault -ResourceGroupName $KeyVault.ResourceGroupName -VaultName $KeyVault.Name
           Write-Output 'Updating Key Vault rules...'
-          $KeyVault | Update-AzKeyVaultNetworkRuleSet -DefaultAction Allow 
+          $KeyVault | Update-AzKeyVaultNetworkRuleSet -DefaultAction Allow
           $LoopCount = 0
-          Write-Output "Waiting for Access..." 
+          Write-Output "Waiting for Access..."
           # This will check every 5 seconds, up to a maximum of 30 seconds
           Do {
               $AccessAllowed = $KeyVault | Get-AzKeyVaultSecret -ErrorAction SilentlyContinue
@@ -323,7 +324,7 @@ stages:
 
 - stage: testapply
   displayName: "Test Apply"
-  dependsOn: 
+  dependsOn:
   - testplan
   - devapply
 
@@ -346,7 +347,7 @@ stages:
           - task: charleszipp.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-installer.TerraformInstaller@0
             displayName: 'Installing Terraform $(Terraform.Version) for apply'
             inputs:
-              terraformVersion: 'latest'
+              terraformVersion: '0.14.9'
 
           - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
             name: RepoCheckout
@@ -362,7 +363,7 @@ stages:
               provider: 'azurerm'
               command: 'init'
               workingDirectory: '$(System.DefaultWorkingDirectory)/azure/infra/terraform'
-              commandOptions: '-backend-config="storage_account_name=s118d01tfbackendsa" -backend-config="container_name=s118t01testfstate"' 
+              commandOptions: '-backend-config="storage_account_name=s118d01tfbackendsa" -backend-config="container_name=s118t01testfstate"'
               backendServiceArm: 'azdo.pipelines.cip.S118T.arm03ce3ff5-9a61-4525-a063-6ecde34874cf'
               backendAzureRmResourceGroupName: 's118t01-tfbackend'
               backendAzureRmStorageAccountName: 's118t01tfbackendsa'
@@ -384,9 +385,9 @@ stages:
                     }
                     $KeyVault = Get-AzKeyVault -ResourceGroupName $KeyVault.ResourceGroupName -VaultName $KeyVault.Name
                     Write-Output 'Updating Key Vault rules...'
-                    $KeyVault | Update-AzKeyVaultNetworkRuleSet -DefaultAction Allow 
+                    $KeyVault | Update-AzKeyVaultNetworkRuleSet -DefaultAction Allow
                     $LoopCount = 0
-                    Write-Output "Waiting for Access..." 
+                    Write-Output "Waiting for Access..."
                     # This will check every 5 seconds, up to a maximum of 30 seconds
                     Do {
                         $AccessAllowed = $KeyVault | Get-AzKeyVaultSecret -ErrorAction SilentlyContinue
@@ -428,12 +429,12 @@ stages:
 
 - stage: prodplan
   displayName: "Production Plan"
-  dependsOn: 
+  dependsOn:
   - devplan
   - testplan
 
   jobs:
-  - job: prodplan 
+  - job: prodplan
     displayName: "Production Plan"
 
     pool:
@@ -443,7 +444,7 @@ stages:
     - task: charleszipp.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-installer.TerraformInstaller@0
       displayName: 'Installing Terraform $(Terraform.Version) for plan'
       inputs:
-        terraformVersion: 'latest'
+        terraformVersion: '0.14.9'
 
     - task: TerraformTaskV1@0
       name: TFInit
@@ -474,9 +475,9 @@ stages:
           }
           $KeyVault = Get-AzKeyVault -ResourceGroupName $KeyVault.ResourceGroupName -VaultName $KeyVault.Name
           Write-Output 'Updating Key Vault rules...'
-          $KeyVault | Update-AzKeyVaultNetworkRuleSet -DefaultAction Allow 
+          $KeyVault | Update-AzKeyVaultNetworkRuleSet -DefaultAction Allow
           $LoopCount = 0
-          Write-Output "Waiting for Access..." 
+          Write-Output "Waiting for Access..."
           # This will check every 5 seconds, up to a maximum of 30 seconds
           Do {
               $AccessAllowed = $KeyVault | Get-AzKeyVaultSecret -ErrorAction SilentlyContinue
@@ -531,7 +532,7 @@ stages:
 
 - stage: prodapply
   displayName: "Production Apply"
-  dependsOn: 
+  dependsOn:
   - testapply
   - prodplan
 
@@ -553,7 +554,7 @@ stages:
           - task: charleszipp.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-installer.TerraformInstaller@0
             displayName: 'Installing Terraform $(Terraform.Version) for apply'
             inputs:
-              terraformVersion: 'latest'
+              terraformVersion: '0.14.9'
 
           - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
             name: RepoCheckout
@@ -591,9 +592,9 @@ stages:
                     }
                     $KeyVault = Get-AzKeyVault -ResourceGroupName $KeyVault.ResourceGroupName -VaultName $KeyVault.Name
                     Write-Output 'Updating Key Vault rules...'
-                    $KeyVault | Update-AzKeyVaultNetworkRuleSet -DefaultAction Allow 
+                    $KeyVault | Update-AzKeyVaultNetworkRuleSet -DefaultAction Allow
                     $LoopCount = 0
-                    Write-Output "Waiting for Access..." 
+                    Write-Output "Waiting for Access..."
                     # This will check every 5 seconds, up to a maximum of 30 seconds
                     Do {
                         $AccessAllowed = $KeyVault | Get-AzKeyVaultSecret -ErrorAction SilentlyContinue

--- a/solution/dqt.integrationtests/QualifiedTeacherStatusServiceTests.cs
+++ b/solution/dqt.integrationtests/QualifiedTeacherStatusServiceTests.cs
@@ -59,7 +59,7 @@ namespace dqt.integrationtests
         [Fact]
         public async void Returns_UnauthorizedRequestResponse_WhenRequestIsUnAuthorized()
         {
-            RequestInfo requestInfo = new RequestInfo()
+            var requestInfo = new RequestInfo
             {
                 TRN = "Test-TRN",
                 NINumber = "Test-NI"
@@ -75,7 +75,7 @@ namespace dqt.integrationtests
         public async void Returns_BadRequestResponse_WhenTRNNotPresent()
         {
 
-            RequestInfo requestInfo = new RequestInfo()
+            var requestInfo = new RequestInfo
             {
                 NINumber = "Test-NI"
             };
@@ -91,7 +91,7 @@ namespace dqt.integrationtests
         [Fact]
         public async void Returns_NotFoundObjectResult_WhenRequestIsValidAndNoMatchFound()
         {
-            RequestInfo requestInfo = new RequestInfo()
+            var requestInfo = new RequestInfo
             {
                 TRN = "Test-TRN",
                 NINumber = "Test-NI"
@@ -108,7 +108,7 @@ namespace dqt.integrationtests
         [Fact]
         public async void Returns_SuccessResponseWithQualifiedTeacherRecords_WhenRequestIsValid()
         {
-            RequestInfo requestInfo = new RequestInfo()
+            var requestInfo = new RequestInfo
             {
                 TRN = "1229708",
                 NINumber = "AP558641W"
@@ -137,7 +137,7 @@ namespace dqt.integrationtests
             var resultDto = (ResultDTO<List<QualifiedTeacherDTO>>)response.Value;
 
             Assert.Equal(200, response.StatusCode);
-            Assert.Single(resultDto.Data);
+            Assert.Equal("0012345", resultDto.Data[0].Trn);
         }
 
         [Fact]
@@ -154,13 +154,13 @@ namespace dqt.integrationtests
             var resultDto = (ResultDTO<List<QualifiedTeacherDTO>>)response.Value;
 
             Assert.Equal(200, response.StatusCode);
-            Assert.Single(resultDto.Data);
+            Assert.Equal("0053100", resultDto.Data[0].Trn);
         }
 
         [Fact]
         public async void Returns_SuccessResponseWithQualifiedTeacherRecords_WhenNIMatchesCaseInsensitively()
         {
-            RequestInfo requestInfo = new RequestInfo()
+            var requestInfo = new RequestInfo
             {
                 TRN = "Test-TRN",
                 NINumber = "aP558641W"


### PR DESCRIPTION
The TRA will issue TRNs in a full seven digit left '0' padded string format in there on going extracts, unfortunately the formatting was removed in a previous extract script. To guard against this we want to ensure that the response API always pads the strings to seven digits to make client validation easier.