### PR TITLE
[CAPT-607] Allow app service to fetch cert from Key vault

### DIFF
--- a/azure/infra/terraform/modules/key_vault/access_policy.tf
+++ b/azure/infra/terraform/modules/key_vault/access_policy.tf
@@ -69,5 +69,6 @@ resource "azurerm_key_vault_access_policy" "secret_kv_access_aas" {
   ]
 
   certificate_permissions = [
+    "Get"
   ]
 }


### PR DESCRIPTION
## What
App service terraform will now fetch the certificate directly from key vault. The service principal must have Get permission

Related to: https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/2270