### PR TITLE
[CAPT-643] Enable geo redundant backups

### DIFF
--- a/azure/infra/terraform/main.tf
+++ b/azure/infra/terraform/main.tf
@@ -60,10 +60,11 @@ module "app_services" {
 }
 
 module "postgres" {
-  source      = "./modules/postgres"
-  app_rg_name = module.resource_group.app_rg_name
-  rg_prefix   = var.rg_prefix
-  rg_location = local.input_region
-  common_tags = local.tags
-  db_name     = var.db_name
+  source                       = "./modules/postgres"
+  app_rg_name                  = module.resource_group.app_rg_name
+  rg_prefix                    = var.rg_prefix
+  rg_location                  = local.input_region
+  common_tags                  = local.tags
+  db_name                      = var.db_name
+  geo_redundant_backup_enabled = var.geo_redundant_backup_enabled
 }

--- a/azure/infra/terraform/modules/postgres/server.tf
+++ b/azure/infra/terraform/modules/postgres/server.tf
@@ -7,7 +7,7 @@ resource "azurerm_postgresql_server" "app_postgres_11" {
 
   storage_mb                   = 5120
   backup_retention_days        = 35
-  geo_redundant_backup_enabled = false
+  geo_redundant_backup_enabled = var.geo_redundant_backup_enabled
   auto_grow_enabled            = false
 
   administrator_login          = data.azurerm_key_vault_secret.postgres_user.value

--- a/azure/infra/terraform/modules/postgres/variable.tf
+++ b/azure/infra/terraform/modules/postgres/variable.tf
@@ -18,3 +18,7 @@ variable "db_name" {
   type        = string
   description = "Database name in the postgres server"
 }
+variable "geo_redundant_backup_enabled" {
+  type        = string
+  description = "Turn Geo-redundant server backups on/off"
+}

--- a/azure/infra/terraform/variables.tf
+++ b/azure/infra/terraform/variables.tf
@@ -17,6 +17,11 @@ variable "db_name" {
   description = "Database name in the postgres server"
   default     = null
 }
+variable "geo_redundant_backup_enabled" {
+  type        = string
+  description = "Turn Geo-redundant server backups on/off"
+  default     = false
+}
 variable "app_service_plan_sku_name" {
   type        = string
   description = "Size of the app service plan"

--- a/azure/infra/terraform/workspace_variables/production.tfvars.json
+++ b/azure/infra/terraform/workspace_variables/production.tfvars.json
@@ -2,5 +2,6 @@
   "rg_prefix": "s118p01",
   "env_tag": "Prod",
   "azdo_sp" : "0b5ab2ba-a1cb-4ede-afda-55fd58279c4b",
-  "db_name": "production"
+  "db_name": "production",
+  "geo_redundant_backup_enabled": true
 }

--- a/azure/infra/terraform/workspace_variables/test.tfvars.json
+++ b/azure/infra/terraform/workspace_variables/test.tfvars.json
@@ -2,5 +2,6 @@
   "rg_prefix": "s118t01",
   "env_tag": "Test",
   "azdo_sp" : "8e5f09a9-5067-4868-a188-36687294baf2",
-  "db_name": "test"
+  "db_name": "test",
+  "geo_redundant_backup_enabled": true
 }


### PR DESCRIPTION
## What
Add a variable to enable geo redundant backups for postgres in test and production

## How to review
It has already been applied, check `Pricing tier`